### PR TITLE
fix the double today-yesterday prompt

### DIFF
--- a/lib/features/goals/widgets/proof_submission_dialog.dart
+++ b/lib/features/goals/widgets/proof_submission_dialog.dart
@@ -216,35 +216,6 @@ class _ProofSubmissionDialogState extends State<ProofSubmissionDialog> {
             const SizedBox(height: 16),
 
             // Yesterday/Today radio buttons, centered, with today on the right side and padding at the bottom
-            Center(
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Radio<bool>(
-                    value: true,
-                    groupValue: yesterday,
-                    onChanged: (value) {
-                      setState(() {
-                        yesterday = value!;
-                      });
-                    },
-                  ),
-                  const Text('Yesterday'),
-                  Radio<bool>(
-                    value: false,
-                    groupValue: yesterday,
-                    onChanged: (value) {
-                      setState(() {
-                        yesterday = value!;
-                      });
-                    },
-                  ),
-                  const Text('Today'),
-                ],
-              ),
-            ),
-
-            // Yesterday/Today radio buttons, centered, with today on the right side and padding at the bottom
             // Only show this if it is not Monday.
             // TODO: CHANGE DAY TO START DAY PARAMETER
 


### PR DESCRIPTION
Fixed double "today vs. yesterday" radio buttons. 